### PR TITLE
High-level README adjustments and crate templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,44 +10,50 @@ The backend's purpose is to facilitate the connection between the [web client](h
 
 \<SUMMARIZE CRATE PURPOSE\>
 
-### Building
+### Usage
 
 #### Prerequisites
 
-- Rust Installation
+- Rust
 
-#### Build Steps
+#### Building
 
-\<EXPAND THIS\>
+\<EXPAND THIS IF NEEDED\>
 
 ```bash
-# Step 1
+# Navigate into the crate directory
 cd tcp-server
 
-# Step 2
-cargo ...
+# Build the crate
+cargo build
+
+# Build and run the crate
+cargo run
 ```
 
 ## tcp-client
 
 \<SUMMARIZE CRATE PURPOSE\>
 
-### Building
+### Usage
 
 #### Prerequisites
 
-- Rust Installation
+- Rust
 
-#### Build Steps
+#### Building
 
-\<EXPAND THIS\>
+\<EXPAND THIS IF NEEDED\>
 
 ```bash
-# Step 1
-cd tcp-client
+# Navigate into the crate directory
+cd tcp-server
 
-# Step 2
-cargo ...
+# Build the crate
+cargo build
+
+# Build and run the crate
+cargo run
 ```
 
 <!-- Navigate into the tcp-server file in a terminal

--- a/README.md
+++ b/README.md
@@ -1,16 +1,69 @@
-Navigate into the tcp-server file in a terminal
+# Project Backend Services
+
+This repository contains the rust crates deployed to our AWS instance to serve as our project's always-on backend.
+
+The backend's purpose is to facilitate the connection between the [web client](https://github.com/CS-Personal-Data-Acquisition-Prototype/UI-Layer) and data collection device. It also stores historical data collection records in an SQLite database. These records are accessable, and archivable, by the web client.
+
+# Crates
+
+## tcp-server
+
+\<SUMMARIZE CRATE PURPOSE\>
+
+### Building
+
+#### Prerequisites
+
+- Rust Installation
+
+#### Build Steps
+
+\<EXPAND THIS\>
+
+```bash
+# Step 1
+cd tcp-server
+
+# Step 2
+cargo ...
+```
+
+## tcp-client
+
+\<SUMMARIZE CRATE PURPOSE\>
+
+### Building
+
+#### Prerequisites
+
+- Rust Installation
+
+#### Build Steps
+
+\<EXPAND THIS\>
+
+```bash
+# Step 1
+cd tcp-client
+
+# Step 2
+cargo ...
+```
+
+<!-- Navigate into the tcp-server file in a terminal
 
 To download packages & dependencies use: cargo build
 
 To run the project use: cargo run
-To run in release mode: cargo run --release
+To run in release mode: cargo run --release -->
 
 # License Notice
+
 To apply the Apache License to your work, attach the following boilerplate notice. The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
     Copyright 2025 CS 462 Personal Data Acquisition Prototype Group
-    
+
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-    
+
     http://www.apache.org/licenses/LICENSE-2.0
     Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
# Summary
This pull request is addresses the ambiguity between the function of this repository and, by proxy, the purpose of the `tcp-server` and `tcp-client` crates implemented across unmerged branches.

I wrote out my best assumption of what this repo is supposed to do, but I need help writing out what the difference in these crates are -- assuming that they're not just an amalgamation of lack of communication and duplicate implementations.

## Actionables

### Those responsible for tcp-server
Based on commit history: @GMcMichael and @cnoah34, can you please justify the `tcp-server` in crate with a push to the `README-improvements` branch?
There are a couple sections in `README.md` to fill out.

### Those responsible for tcp-client
Based on commit history: @lyxxng, can you please justify the `tcp-client` crate with a push to the `README-improvements` branch?
There are a couple sections in `README.md` to fill out.

> [!NOTE]
> If these crates need combined, let me know and I can adjust this PR to combine them.
> @typedef-mukyu, being the codebase admin, I've requested your review as well.

Be mean to me if I am out of line with this PR, I like documentation a little too much.